### PR TITLE
More conformation to ReleaseThirdParty#Modifying_the_Release_Repository

### DIFF
--- a/patches/package.xml
+++ b/patches/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>csm</name>
-  <version>1.0.2</version>
+  <version>:{version}</version>
   <description>
     This is a ROS 3rd-party wrapper <a href = "http://www.ros.org/reps/rep-0136.html">(see REP-136 for more detail)</a> of Andrea Censi's CSM package. 
 
@@ -23,7 +23,8 @@
   <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I.Y. Saito</maintainer>
 
   <buildtool_depend>cmake</buildtool_depend>
-  <run_depend>libgsl</run_depend>
   <build_depend>libgsl</build_depend>
+  <run_depend>catkin</run_depend>
+  <run_depend>libgsl</run_depend>
   <export />
 </package>


### PR DESCRIPTION
Current `package.xml` seems to be working. This PR is just for future purpose.

Mentioned in http://wiki.ros.org/bloom/Tutorials/ReleaseThirdParty#Modifying_the_Release_Repository:
- `Also, rather than putting an actual version in the <version> tag put :{version}. :{version} will be replaced by the version being released each time.`
- `Now create package.xml in the folder you just created using this: catkin/package.xml as a reference, making sure to run_depend on catkin.`
